### PR TITLE
Fix issue with newer pytorch versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,27 +10,24 @@ Formally, REMIND takes an input image and passes it through frozen layers of a n
 
 ## Dependencies 
 
-:warning::warning: | For unknown reasons, our code does not reproduce results in PyTorch versions greater than PyTorch 1.3.1. Please follow our instructions below to ensure reproducibility.
-:---: | :---
-
 We have tested the code with the following packages and versions:
-- Python 3.7.6
-- PyTorch (GPU) 1.3.1
-- torchvision 0.4.2
-- NumPy 1.18.5
+- Python 3.8.13
+- PyTorch (GPU) 1.12.1
+- torchvision 0.13.1
+- NumPy 1.21.5
 - FAISS (CPU) 1.5.2
-- CUDA 10.1 (also works with CUDA 10.0)
-- Scikit-Learn 0.23.1
-- Scipy 1.1.0
+- CUDA 10.2 (also works with CUDA 11.3)
+- Scikit-Learn 1.0.2
+- Scipy 1.7.3
 - NVIDIA GPU
 
 
 We recommend setting up a `conda` environment with these same package versions:
 ```
-conda create -n remind_proj python=3.7
+conda create -n remind_proj python=3.8
 conda activate remind_proj
-conda install numpy=1.18.5
-conda install pytorch=1.3.1 torchvision=0.4.2 cudatoolkit=10.1 -c pytorch
+conda install numpy=1.21.5
+conda install pytorch=1.12.1 torchvision=0.13.1 cudatoolkit=10.2 -c pytorch
 conda install faiss-cpu=1.5.2 -c pytorch
 ```
 

--- a/image_classification_experiments/utils.py
+++ b/image_classification_experiments/utils.py
@@ -52,7 +52,7 @@ def accuracy(output, target, topk=(1,), output_has_class_ids=False):
 
         res = []
         for k in topk:
-            correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+            correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True)
             res.append(correct_k.mul_(100.0 / batch_size).item())
         return res
 


### PR DESCRIPTION
This fixes the performance issue that REMIND has when using newer pytorch versions. 

The issue happens when using the 'step_lr_per_class' setting. The learning rate does not reset automatically after every class, meaning that each scheduler does not have its own learning rate; instead, it starts with the latest learning rate causing the learning rate to decrease rapidly. With the proposed changes, the learning rate for each scheduler is being reset manually. This fixes the issue.

Results on ImageNet CLS IID:

| Code | Pytorch version (GPU)| Metric| 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000 | Omega |
| ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- |
| Original | 1.3.1| seen_classes_top5| 94.00 | 87.57 | 83.33 | 79.54 | 76.62 | 75.80 | 74.37 | 72.97 | 71.90 | 70.68 | 0.855 |
| Original | 1.12.1| seen_classes_top5|  94.10 | 47.44 | 31.60 | 23.70 | 18.97 | 15.80 | 13.56 | 11.85 |  10.53 | 9.48 | 0.297 |
| With changes | 1.12.1| seen_classes_top5| 94.10 | 87.26 | 82.51 | 79.88 | 77.08 | 75.56 | 74.01 | 72.92 | 72.15 | 70.77 | 0.854 |

We can see that running the original code on newer pytorch versions (1.12.1) yields poor performance. Using the proposed changes with pytorch 1.12.1 yields similar performance to the original code on pytorch 1.3.1.

I have tested the code changes with the following packages and versions:
- Python 3.8.13
- PyTorch (GPU) 1.12.1
- torchvision 0.13.1
- NumPy 1.21.5
- FAISS (CPU) 1.5.2
- CUDA 10.2 (also works with CUDA 11.3)
- Scikit-Learn 1.0.2
- Scipy 1.7.3
- NVIDIA GPU
